### PR TITLE
Add jest test for service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dynast.github.io",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.2",
+    "jsdom": "^24.0.0"
+  }
+}

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('service worker registration', () => {
+  test('navigator.serviceWorker.register is called when page loads', async () => {
+    const registerMock = jest.fn(() => Promise.resolve());
+
+    const dom = await JSDOM.fromFile(path.join(__dirname, '../service-workers/index.html'), {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      beforeParse(window) {
+        window.navigator.serviceWorker = { register: registerMock };
+      }
+    });
+
+    await new Promise(resolve => {
+      dom.window.addEventListener('load', () => resolve());
+    });
+
+    expect(registerMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `package.json` with jest-based test script
- ignore `node_modules`
- add JSDOM test ensuring service worker registration occurs

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684194cc74348330b0bd55ab7abf6b7f